### PR TITLE
net_http_persistent adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ client = Antbird::Client.new(
     type: 'test-type'
   }
 ) do |f|
+  # https://github.com/lostisland/faraday/blob/master/docs/adapters/net_http_persistent.md
+  f.adapter :net_http_persistent, pool_size: 5 do |http|
+    http.idle_timeout = 100
+  end
+
+  # https://github.com/winebarrel/faraday_middleware-aws-sigv4
   f.request(
     :aws_sigv4,
     service: 'es',

--- a/antbird.gemspec
+++ b/antbird.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", "> 0.8", "< 2.0"
   spec.add_dependency 'faraday_middleware', "> 0.12", "< 1.0"
 
+  spec.add_development_dependency "net-http-persistent"
   spec.add_development_dependency "bundler", "> 1.16", "< 3.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/antbird/client.rb
+++ b/lib/antbird/client.rb
@@ -151,12 +151,10 @@ module Antbird
       @connection ||= Faraday.new(url) do |conn|
         @block.call(conn) if @block
         conn.request :json
-        conn.response :json, :content_type => /\bjson$/
+        conn.response :json, content_type: /\bjson$/
 
         conn.options[:timeout]      = read_timeout
         conn.options[:open_timeout] = open_timeout
-
-        conn.adapter Faraday.default_adapter
       end
     end
 

--- a/spec/lib/antbird/client_spec.rb
+++ b/spec/lib/antbird/client_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Antbird::Client do
       it 'not call request' do
         expect_any_instance_of(Faraday::Connection).not_to receive(:request)
       end
+
+      it 'use default adapter' do
+        expect(instance.connection.adapter).to eq(Faraday::Adapter::NetHttp)
+      end
     end
 
     context 'url specified' do
@@ -38,6 +42,18 @@ RSpec.describe Antbird::Client do
       end
     end
 
+    context 'adapter: net_http_persistent' do
+      subject(:instance) do
+        described_class.new do |f|
+          f.adapter :net_http_persistent
+        end
+      end
+
+      it 'use net_http_persistent adapter' do
+        expect(instance.connection.adapter).to eq(Faraday::Adapter::NetHttpPersistent)
+      end
+    end
+
     context 'faraday_middleware' do
       subject(:instance) do
         client = described_class.new do |f|
@@ -45,6 +61,7 @@ RSpec.describe Antbird::Client do
         end
         client.cat_indices
       end
+
       it do
         expect_any_instance_of(Faraday::Connection).to receive(:request).with(:foo_middleware)
         expect_any_instance_of(Faraday::Connection).to receive(:request).and_call_original


### PR DESCRIPTION
fix #24 

- Enable to Use net_http_persistent easily
- Add spec for net_http_persistent
- Add description about net_http_persistent on README