### PR TITLE
Fix guessing API Path & HTTP Method

### DIFF
--- a/lib/antbird/client.rb
+++ b/lib/antbird/client.rb
@@ -49,7 +49,7 @@ module Antbird
       api_path = nil
       api_path_template = nil
       path_methods = nil
-      api_spec['url']['paths'].sort { |a, b| b.size <=> a.size }.each do |path|
+      sort_url_paths(api_spec['url']['paths']).each do |path|
         if path.is_a?(Hash)
           path_methods = path['methods']
           path = path['path']
@@ -191,6 +191,18 @@ module Antbird
     end
 
     private
+
+    # NOTE: stable sort
+    def sort_url_paths(url_paths)
+      i = 0
+      url_paths.sort_by do |path|
+        if path.is_a?(Hash)
+          [-path['path'].count('{'), (path['deprecated'] ? 1 : 0), i += 1]
+        else
+          [-path.count('{'), i += 1]
+        end
+      end
+    end
 
     def handle_errors!(response)
       if response.status >= 500

--- a/spec/lib/antbird/client_spec.rb
+++ b/spec/lib/antbird/client_spec.rb
@@ -192,6 +192,8 @@ RSpec.describe Antbird::Client do
 
         # `timeout` param should be dropped if nil
         client.index(id: 'doc-1', body: { field1: 'foo bar' }, timeout: nil)
+        expect(client.last_request[:method]).to eq(:put)
+
         client.indices_refresh
 
         expect(client.search(body: match_all_query)['hits']['hits'].first['_id']).to eq('doc-1')


### PR DESCRIPTION
- Fix guessing API path
    - Use stable sort
    - Lower priority for deprecated path
- Change guessing API Method priority:
    1. Specified by user (new)
    1. Use `PUT` if available (new)
    1. Use `POST` if available
    1. First HTTP Method on spec

