### PR TITLE
Support per-operation timeout overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,67 @@ client.bulk(body: [
 ])
 ```
 
+### Timeouts
+
+Default connection timeouts are configured when the client is created:
+
+```ruby
+client = Antbird::Client.new(
+  read_timeout: 5,   # seconds (default)
+  open_timeout: 2,   # seconds (default)
+  write_timeout: 30, # seconds (default: nil => falls back to read_timeout)
+)
+```
+
+`write_timeout` is optional. When omitted it is left unset and the adapter
+falls back to `read_timeout` for the write phase, preserving existing behavior.
+
+Timeouts can be overridden per operation. There are two ways to do it:
+
+1. `http_timeout` — a shorthand that sets the `read`, `open` and `write`
+   timeouts all at once for that single request:
+
+   ```ruby
+   # This request alone uses a 60s timeout for read/open/write.
+   client.search(body: { query: { match_all: {} } }, http_timeout: 60)
+
+   # Long-running reindex; give it more time without affecting other calls.
+   client.reindex(body: { source: { index: 'a' }, dest: { index: 'b' } }, http_timeout: 600)
+   ```
+
+2. `read_timeout` / `open_timeout` / `write_timeout` — override individual
+   phases. These may be combined with each other:
+
+   ```ruby
+   client.bulk(body: [...], open_timeout: 3, write_timeout: 30)
+   ```
+
+When none of these is given, the client falls back to the values configured at
+initialization time.
+
+`http_timeout` is mutually exclusive with `read_timeout` / `open_timeout` /
+`write_timeout`. Passing `http_timeout` together with any of them raises an
+`ArgumentError`:
+
+```ruby
+client.search(body: {...}, http_timeout: 60, open_timeout: 3) # => ArgumentError
+```
+
+All of the above are client-side (HTTP) timeouts and do not collide with the
+server-side `timeout` query parameter that some OpenSearch APIs accept — both
+can be passed together:
+
+```ruby
+client.bulk(
+  body: [...],
+  timeout: '30s',    # OpenSearch server-side timeout (query parameter)
+  http_timeout: 60,  # HTTP read/open/write timeout (Faraday)
+)
+```
+
+> `read_timeout` sets Faraday's global `:timeout` (preserving its original
+> behavior), while `open_timeout` / `write_timeout` set those specific phases.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Timeouts can be overridden per operation. There are two ways to do it:
    phases. These may be combined with each other:
 
    ```ruby
-   client.bulk(body: [...], open_timeout: 3, write_timeout: 30)
+   client.bulk(body: [{ index: { _id: '1' } }, { field1: 'a' }], open_timeout: 3, write_timeout: 30)
    ```
 
 When none of these is given, the client falls back to the values configured at
@@ -142,7 +142,7 @@ initialization time.
 `ArgumentError`:
 
 ```ruby
-client.search(body: {...}, http_timeout: 60, open_timeout: 3) # => ArgumentError
+client.search(body: { query: { match_all: {} } }, http_timeout: 60, open_timeout: 3) # => ArgumentError
 ```
 
 All of the above are client-side (HTTP) timeouts and do not collide with the
@@ -151,7 +151,7 @@ can be passed together:
 
 ```ruby
 client.bulk(
-  body: [...],
+  body: [{ index: { _id: '1' } }, { field1: 'a' }],
   timeout: '30s',    # OpenSearch server-side timeout (query parameter)
   http_timeout: 60,  # HTTP read/open/write timeout (Faraday)
 )

--- a/lib/antbird/client.rb
+++ b/lib/antbird/client.rb
@@ -9,14 +9,16 @@ module Antbird
       version: nil,
       read_timeout: 5,
       open_timeout: 2,
+      write_timeout: nil,
       adapter: ::Faraday.default_adapter,
       &block)
 
-      @read_timeout = read_timeout
-      @open_timeout = open_timeout
-      @adapter      = adapter
-      @block        = block
-      @url          = url
+      @read_timeout  = read_timeout
+      @open_timeout  = open_timeout
+      @write_timeout = write_timeout
+      @adapter       = adapter
+      @block         = block
+      @url           = url
 
       @scope        = scope.transform_keys(&:to_sym)
 
@@ -25,7 +27,7 @@ module Antbird
       @api_specs = {}
     end
     attr_reader :scope, :url
-    attr_reader :read_timeout, :open_timeout, :adapter
+    attr_reader :read_timeout, :open_timeout, :write_timeout, :adapter
     attr_reader :api_specs, :last_request
 
     def scoped(new_scope = {})
@@ -35,6 +37,7 @@ module Antbird
         version: version,
         read_timeout: read_timeout,
         open_timeout: open_timeout,
+        write_timeout: write_timeout,
         adapter: adapter,
         &@block
       )
@@ -84,7 +87,7 @@ module Antbird
           methods.first
         end
 
-      read_timeout = params.delete(:read_timeout)
+      timeout_options = extract_timeout_options(params)
       params.reject! { |_, v| v.nil? }
 
       @last_request = {
@@ -100,29 +103,29 @@ module Antbird
         when :head
           connection.head(api_path) do |req|
             req.params = params unless params.empty?
-            req.options[:timeout] = read_timeout if read_timeout
+            apply_timeouts(req, timeout_options)
           end
         when :get
           connection.get(api_path) do |req|
             req.params = params unless params.empty?
             req.body = body if body
-            req.options[:timeout] = read_timeout if read_timeout
+            apply_timeouts(req, timeout_options)
           end
         when :put
           connection.put(api_path, body) do |req|
             req.params = params unless params.empty?
-            req.options[:timeout] = read_timeout if read_timeout
+            apply_timeouts(req, timeout_options)
           end
         when :post
           connection.post(api_path, body) do |req|
             req.params = params unless params.empty?
-            req.options[:timeout] = read_timeout if read_timeout
+            apply_timeouts(req, timeout_options)
           end
         when :delete
           connection.delete(api_path) do |req|
             req.params = params unless params.empty?
             req.body = body if body
-            req.options[:timeout] = read_timeout if read_timeout
+            apply_timeouts(req, timeout_options)
           end
         else
           raise ArgumentError, "Unknown HTTP request method: #{method.inspect}"
@@ -139,6 +142,39 @@ module Antbird
 
       handle_errors!(response)
       response.body
+    end
+
+    # Builds the per-operation Faraday timeout options from the request params.
+    # - http_timeout: overrides read/open/write timeouts all at once. It is
+    #   mutually exclusive with read_timeout/open_timeout/write_timeout.
+    # - read_timeout: legacy per-operation override (sets Faraday's :timeout).
+    # - open_timeout / write_timeout: per-operation overrides for those phases.
+    # The granular options may be combined with each other.
+    # When none is given, the connection-level defaults are used.
+    def extract_timeout_options(params)
+      http_timeout  = params.delete(:http_timeout)
+      read_timeout  = params.delete(:read_timeout)
+      open_timeout  = params.delete(:open_timeout)
+      write_timeout = params.delete(:write_timeout)
+
+      if http_timeout && (read_timeout || open_timeout || write_timeout)
+        raise ArgumentError,
+          ":http_timeout cannot be combined with :read_timeout, :open_timeout or :write_timeout"
+      end
+
+      if http_timeout
+        return { open_timeout: http_timeout, read_timeout: http_timeout, write_timeout: http_timeout }
+      end
+
+      options = {}
+      options[:timeout]       = read_timeout  if read_timeout
+      options[:open_timeout]  = open_timeout  if open_timeout
+      options[:write_timeout] = write_timeout if write_timeout
+      options
+    end
+
+    def apply_timeouts(req, timeout_options)
+      timeout_options.each { |key, value| req.options[key] = value }
     end
 
     def extract_method(params)
@@ -185,8 +221,9 @@ module Antbird
         conn.request :json
         conn.response :json, content_type: /\bjson$/
 
-        conn.options[:timeout]      = read_timeout
-        conn.options[:open_timeout] = open_timeout
+        conn.options[:timeout]       = read_timeout
+        conn.options[:open_timeout]  = open_timeout
+        conn.options[:write_timeout] = write_timeout if write_timeout
 
         conn.adapter adapter
       end
@@ -221,7 +258,7 @@ module Antbird
       end
     end
 
-    SPECIAL_PARAMS = %i[body method read_timeout].freeze
+    SPECIAL_PARAMS = %i[body method http_timeout read_timeout open_timeout write_timeout].freeze
 
     def validate_params(api_spec, params, path_params)
       if api_spec.dig('body', 'required') && !params.key?(:body)

--- a/lib/antbird/client.rb
+++ b/lib/antbird/client.rb
@@ -151,6 +151,11 @@ module Antbird
     # - open_timeout / write_timeout: per-operation overrides for those phases.
     # The granular options may be combined with each other.
     # When none is given, the connection-level defaults are used.
+    #
+    # The read phase is set via Faraday's :timeout key (consistent with the
+    # legacy read_timeout path and the connection-level default); :open_timeout
+    # and :write_timeout are set explicitly so http_timeout overrides them even
+    # when the connection configures its own defaults.
     def extract_timeout_options(params)
       http_timeout  = params.delete(:http_timeout)
       read_timeout  = params.delete(:read_timeout)
@@ -163,7 +168,7 @@ module Antbird
       end
 
       if http_timeout
-        return { open_timeout: http_timeout, read_timeout: http_timeout, write_timeout: http_timeout }
+        return { timeout: http_timeout, open_timeout: http_timeout, write_timeout: http_timeout }
       end
 
       options = {}

--- a/lib/antbird/client.rb
+++ b/lib/antbird/client.rb
@@ -144,44 +144,6 @@ module Antbird
       response.body
     end
 
-    # Builds the per-operation Faraday timeout options from the request params.
-    # - http_timeout: overrides read/open/write timeouts all at once. It is
-    #   mutually exclusive with read_timeout/open_timeout/write_timeout.
-    # - read_timeout: legacy per-operation override (sets Faraday's :timeout).
-    # - open_timeout / write_timeout: per-operation overrides for those phases.
-    # The granular options may be combined with each other.
-    # When none is given, the connection-level defaults are used.
-    #
-    # The read phase is set via Faraday's :timeout key (consistent with the
-    # legacy read_timeout path and the connection-level default); :open_timeout
-    # and :write_timeout are set explicitly so http_timeout overrides them even
-    # when the connection configures its own defaults.
-    def extract_timeout_options(params)
-      http_timeout  = params.delete(:http_timeout)
-      read_timeout  = params.delete(:read_timeout)
-      open_timeout  = params.delete(:open_timeout)
-      write_timeout = params.delete(:write_timeout)
-
-      if http_timeout && (read_timeout || open_timeout || write_timeout)
-        raise ArgumentError,
-          ":http_timeout cannot be combined with :read_timeout, :open_timeout or :write_timeout"
-      end
-
-      if http_timeout
-        return { timeout: http_timeout, open_timeout: http_timeout, write_timeout: http_timeout }
-      end
-
-      options = {}
-      options[:timeout]       = read_timeout  if read_timeout
-      options[:open_timeout]  = open_timeout  if open_timeout
-      options[:write_timeout] = write_timeout if write_timeout
-      options
-    end
-
-    def apply_timeouts(req, timeout_options)
-      timeout_options.each { |key, value| req.options[key] = value }
-    end
-
     def extract_method(params)
       params.delete(:method)&.to_sym
     end
@@ -242,6 +204,44 @@ module Antbird
     end
 
     private
+
+    # Builds the per-operation Faraday timeout options from the request params.
+    # - http_timeout: overrides read/open/write timeouts all at once. It is
+    #   mutually exclusive with read_timeout/open_timeout/write_timeout.
+    # - read_timeout: legacy per-operation override (sets Faraday's :timeout).
+    # - open_timeout / write_timeout: per-operation overrides for those phases.
+    # The granular options may be combined with each other.
+    # When none is given, the connection-level defaults are used.
+    #
+    # The read phase is set via Faraday's :timeout key (consistent with the
+    # legacy read_timeout path and the connection-level default); :open_timeout
+    # and :write_timeout are set explicitly so http_timeout overrides them even
+    # when the connection configures its own defaults.
+    def extract_timeout_options(params)
+      http_timeout  = params.delete(:http_timeout)
+      read_timeout  = params.delete(:read_timeout)
+      open_timeout  = params.delete(:open_timeout)
+      write_timeout = params.delete(:write_timeout)
+
+      if http_timeout && (read_timeout || open_timeout || write_timeout)
+        raise ArgumentError,
+          ":http_timeout cannot be combined with :read_timeout, :open_timeout or :write_timeout"
+      end
+
+      if http_timeout
+        return { timeout: http_timeout, open_timeout: http_timeout, write_timeout: http_timeout }
+      end
+
+      options = {}
+      options[:timeout]       = read_timeout  if read_timeout
+      options[:open_timeout]  = open_timeout  if open_timeout
+      options[:write_timeout] = write_timeout if write_timeout
+      options
+    end
+
+    def apply_timeouts(req, timeout_options)
+      timeout_options.each { |key, value| req.options[key] = value }
+    end
 
     # NOTE: stable sort
     def sort_url_paths(url_paths)

--- a/spec/lib/antbird/client_spec.rb
+++ b/spec/lib/antbird/client_spec.rb
@@ -384,9 +384,15 @@ RSpec.describe Antbird::Client do
       }.not_to raise_error
     end
 
-    it 'accepts special params (method, http_timeout, read_timeout, open_timeout, write_timeout)' do
+    it 'accepts special params (method, read_timeout, open_timeout, write_timeout)' do
       expect {
-        client.send(:validate_params, api_spec, { body: {}, q: 'test', method: :get, http_timeout: 30, read_timeout: 10, open_timeout: 3, write_timeout: 7 }, path_params)
+        client.send(:validate_params, api_spec, { body: {}, q: 'test', method: :get, read_timeout: 10, open_timeout: 3, write_timeout: 7 }, path_params)
+      }.not_to raise_error
+    end
+
+    it 'accepts http_timeout as a special param' do
+      expect {
+        client.send(:validate_params, api_spec, { body: {}, q: 'test', http_timeout: 30 }, path_params)
       }.not_to raise_error
     end
 

--- a/spec/lib/antbird/client_spec.rb
+++ b/spec/lib/antbird/client_spec.rb
@@ -386,7 +386,7 @@ RSpec.describe Antbird::Client do
 
     it 'accepts special params (method, http_timeout, read_timeout, open_timeout, write_timeout)' do
       expect {
-        client.send(:validate_params, api_spec, { body: {}, q: 'test', method: :get, read_timeout: 10, open_timeout: 3, write_timeout: 7 }, path_params)
+        client.send(:validate_params, api_spec, { body: {}, q: 'test', method: :get, http_timeout: 30, read_timeout: 10, open_timeout: 3, write_timeout: 7 }, path_params)
       }.not_to raise_error
     end
 
@@ -408,9 +408,9 @@ RSpec.describe Antbird::Client do
     end
 
     context 'when http_timeout is given' do
-      it 'sets read, open and write timeouts to that value' do
+      it 'sets read (:timeout), open and write timeouts to that value' do
         expect(extract(http_timeout: 30)).to eq(
-          read_timeout: 30, open_timeout: 30, write_timeout: 30
+          timeout: 30, open_timeout: 30, write_timeout: 30
         )
       end
     end

--- a/spec/lib/antbird/client_spec.rb
+++ b/spec/lib/antbird/client_spec.rb
@@ -63,6 +63,36 @@ RSpec.describe Antbird::Client do
         expect { subject }.not_to raise_error
       end
     end
+
+    context 'timeouts' do
+      it 'applies the default read/open timeouts to the connection' do
+        options = described_class.new.connection.options
+
+        expect(options[:timeout]).to eq(5)
+        expect(options[:open_timeout]).to eq(2)
+      end
+
+      it 'does not set write_timeout by default (falls back to :timeout)' do
+        options = described_class.new.connection.options
+
+        expect(options[:write_timeout]).to be_nil
+      end
+
+      it 'allows configuring write_timeout at initialization' do
+        options = described_class.new(write_timeout: 30).connection.options
+
+        expect(options[:write_timeout]).to eq(30)
+      end
+
+      it 'carries timeouts over to scoped clients' do
+        client = described_class.new(read_timeout: 7, open_timeout: 3, write_timeout: 30)
+        scoped = client.scoped(index: 'foo')
+
+        expect(scoped.read_timeout).to eq(7)
+        expect(scoped.open_timeout).to eq(3)
+        expect(scoped.write_timeout).to eq(30)
+      end
+    end
   end
 
   describe 'handle_errors' do
@@ -354,9 +384,9 @@ RSpec.describe Antbird::Client do
       }.not_to raise_error
     end
 
-    it 'accepts special params (method, read_timeout)' do
+    it 'accepts special params (method, http_timeout, read_timeout, open_timeout, write_timeout)' do
       expect {
-        client.send(:validate_params, api_spec, { body: {}, q: 'test', method: :get, read_timeout: 10 }, path_params)
+        client.send(:validate_params, api_spec, { body: {}, q: 'test', method: :get, read_timeout: 10, open_timeout: 3, write_timeout: 7 }, path_params)
       }.not_to raise_error
     end
 
@@ -367,6 +397,80 @@ RSpec.describe Antbird::Client do
       expect {
         client.send(:validate_params, spec_without_params, { anything: 'goes' }, [])
       }.not_to raise_error
+    end
+  end
+
+  describe '#extract_timeout_options' do
+    let(:client) { described_class.new }
+
+    def extract(params)
+      client.send(:extract_timeout_options, params)
+    end
+
+    context 'when http_timeout is given' do
+      it 'sets read, open and write timeouts to that value' do
+        expect(extract(http_timeout: 30)).to eq(
+          read_timeout: 30, open_timeout: 30, write_timeout: 30
+        )
+      end
+    end
+
+    context 'when only read_timeout is given' do
+      it 'sets Faraday :timeout only (legacy behavior)' do
+        expect(extract(read_timeout: 10)).to eq(timeout: 10)
+      end
+    end
+
+    context 'when open_timeout and write_timeout are given' do
+      it 'sets only those phases' do
+        expect(extract(open_timeout: 3, write_timeout: 7)).to eq(
+          open_timeout: 3, write_timeout: 7
+        )
+      end
+    end
+
+    context 'when the granular options are combined' do
+      it 'sets each one independently' do
+        expect(extract(read_timeout: 10, open_timeout: 3, write_timeout: 7)).to eq(
+          timeout: 10, open_timeout: 3, write_timeout: 7
+        )
+      end
+    end
+
+    context 'when none is given' do
+      it 'returns an empty hash (connection-level defaults are used)' do
+        expect(extract({})).to eq({})
+      end
+    end
+
+    it 'removes the timeout keys from params' do
+      params = { q: 'test', http_timeout: 30 }
+      extract(params)
+      expect(params).to eq(q: 'test')
+    end
+
+    [:read_timeout, :open_timeout, :write_timeout].each do |granular|
+      it "raises ArgumentError when http_timeout is combined with #{granular}" do
+        expect {
+          extract(http_timeout: 30, granular => 10)
+        }.to raise_error(ArgumentError, /:http_timeout cannot be combined with/)
+      end
+    end
+  end
+
+  describe '#request timeout validation' do
+    let(:client) { described_class.new }
+    let(:api_spec) do
+      {
+        'url' => { 'paths' => [{ 'path' => '/_search', 'methods' => ['GET', 'POST'] }] },
+        'body' => { 'required' => true }
+      }
+    end
+
+    it 'raises ArgumentError when http_timeout is combined with a granular timeout' do
+      expect {
+        client.request('search', api_spec, { body: {}, http_timeout: 60, read_timeout: 10 })
+      }.to raise_error(ArgumentError, /:http_timeout cannot be combined with/)
     end
   end
 


### PR DESCRIPTION
## Summary

Adds per-operation timeout overrides that can be passed to any API call, plus a configurable `write_timeout` default at client initialization.

### Per-operation overrides

| Option | Effect |
|---|---|
| `http_timeout` | Shorthand — sets read/open/write timeouts all at once |
| `read_timeout` (existing) | Sets Faraday's `:timeout` (legacy behavior preserved) |
| `open_timeout` | Overrides the open (connect) phase |
| `write_timeout` | Overrides the write phase |

```ruby
# set everything at once for one slow request
client.reindex(body: {...}, http_timeout: 600)

# or override individual phases (combinable)
client.bulk(body: [...], open_timeout: 3, write_timeout: 30)
```

- `http_timeout` is **mutually exclusive** with `read_timeout` / `open_timeout` / `write_timeout`; combining them raises `ArgumentError`.
- The granular options may be combined with each other.
- When none is given, the connection-level defaults (set at init) are used — backward compatible.

### Naming note

The new options are named `*_timeout` (not `timeout`) on purpose: OpenSearch's own server-side `timeout` query parameter is used by 50+ APIs. Keeping distinct names lets both be passed together without collision:

```ruby
client.bulk(
  body: [...],
  timeout: '30s',    # OpenSearch server-side timeout (query parameter)
  http_timeout: 60,  # HTTP read/open/write timeout (Faraday)
)
```

### Client init

`write_timeout` is now configurable at `Antbird::Client.new` (default `nil`, falling back to `read_timeout` for the write phase to preserve existing behavior).

## Test plan

- [x] `bundle exec rspec` — 42 examples, 0 failures (run against local OpenSearch)
- [x] Manually verified per-operation `open_timeout` / `write_timeout` enforcement, granular combination, `http_timeout` + granular `ArgumentError`, and coexistence with the server-side `timeout` query param

🤖 Generated with [Claude Code](https://claude.com/claude-code)